### PR TITLE
bugfix - use resampled n_samples audio_csv.py

### DIFF
--- a/src/data/audio_csv.py
+++ b/src/data/audio_csv.py
@@ -136,6 +136,7 @@ class AudioCSVDataset(Dataset):
         if sr != target_sr:
             y = F.resample(y, sr, target_sr)
             sr = target_sr
+            n_samples = y.shape[0]
             
         # pad or crop
         if n_samples < target_frames:


### PR DESCRIPTION
Seems we should be using n_samples after the resample when `sr != target_sr` to avoid index error